### PR TITLE
Fix pkg_config::target_supported missing causing build error.

### DIFF
--- a/libdw-sys/Cargo.toml
+++ b/libdw-sys/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 dependencies = [ "libdw-dev" ]
 
 [build-dependencies]
-pkg-config = "0.3.8"
+pkg-config = "0.3.15"
 
 [dependencies]
 libc = "0.2"

--- a/libdw-sys/build.rs
+++ b/libdw-sys/build.rs
@@ -1,7 +1,7 @@
 extern crate pkg_config;
 
 fn main() {
-    assert!(pkg_config::target_supported());
+    assert!(pkg_config::Config::new().target_supported());
     if pkg_config::probe_library("libdw").is_err() {
         // Guess!  This probably won't work in general, but it helps to have a
         // shim for cases like docs.rs that don't really need to build.

--- a/libdw-sys/build.rs
+++ b/libdw-sys/build.rs
@@ -1,8 +1,9 @@
 extern crate pkg_config;
 
 fn main() {
-    assert!(pkg_config::Config::new().target_supported());
-    if pkg_config::probe_library("libdw").is_err() {
+    let config = pkg_config::Config::new();
+    assert!(config.target_supported());
+    if config.probe("libdw").is_err() {
         // Guess!  This probably won't work in general, but it helps to have a
         // shim for cases like docs.rs that don't really need to build.
         println!("cargo:rustc-link-lib=dw");

--- a/libelf-sys/Cargo.toml
+++ b/libelf-sys/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 dependencies = [ "libelf-dev" ]
 
 [build-dependencies]
-pkg-config = "0.3.8"
+pkg-config = "0.3.15"
 
 [dependencies]
 libc = "0.2"

--- a/libelf-sys/build.rs
+++ b/libelf-sys/build.rs
@@ -1,8 +1,9 @@
 extern crate pkg_config;
 
 fn main() {
-    assert!(pkg_config::Config::new().target_supported());
-    if pkg_config::probe_library("libelf").is_err() {
+    let config = pkg_config::Config::new();
+    assert!(config.target_supported());
+    if config.probe("libelf").is_err() {
         // Guess!  This probably won't work in general, but it helps to have a
         // shim for cases like docs.rs that don't really need to build.
         println!("cargo:rustc-link-lib=elf");

--- a/libelf-sys/build.rs
+++ b/libelf-sys/build.rs
@@ -1,7 +1,7 @@
 extern crate pkg_config;
 
 fn main() {
-    assert!(pkg_config::target_supported());
+    assert!(pkg_config::Config::new().target_supported());
     if pkg_config::probe_library("libelf").is_err() {
         // Guess!  This probably won't work in general, but it helps to have a
         // shim for cases like docs.rs that don't really need to build.


### PR DESCRIPTION
On my machine (a raspberry pi 4 running Manjaro), I get an error saying that pkg_config doesn't contain target_supported.
I'm not too familiar with rust or how to navigate it, but after a little digging it looks like it's inside the Config type.

The docs for pkg_config (https://docs.rs/pkg-config/0.3.8/pkg_config/index.html) lead me to believe
that it's fine to just new() up a Config and use that.

Testing done:
- cargo test
- cargo test --release

Output of uname -a:
Linux pi 5.10.81-1-MANJARO-ARM-RPI #1 SMP PREEMPT Thu Nov 25 07:43:21 CST 2021 aarch64 GNU/Linux